### PR TITLE
enforce single validator in staking module

### DIFF
--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -35,6 +35,15 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 		return nil, err
 	}
 
+	/*
+		As long as decentralized sequencer isn't supported,
+		don't allow to create more than single validator
+	*/
+	validators := k.GetValidators(ctx, 1)
+	if len(validators) > 0 {
+		return nil, types.ErrSingleSequencerSupported
+	}
+
 	// check to see if the pubkey or sender has been registered before
 	if _, found := k.GetValidator(ctx, valAddr); found {
 		return nil, types.ErrValidatorOwnerExists

--- a/x/staking/types/errors.go
+++ b/x/staking/types/errors.go
@@ -49,4 +49,5 @@ var (
 	ErrInvalidHistoricalInfo           = sdkerrors.Register(ModuleName, 37, "invalid historical info")
 	ErrNoHistoricalInfo                = sdkerrors.Register(ModuleName, 38, "no historical info found")
 	ErrEmptyValidatorPubKey            = sdkerrors.Register(ModuleName, 39, "empty validator public key")
+	ErrSingleSequencerSupported        = sdkerrors.Register(ModuleName, 100, "single sequencer supported")
 )


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #158 

Staking module allows creation of single validator only
